### PR TITLE
State checks for assembler and blastdoor

### DIFF
--- a/Hope_TFlippy_TerritoryControl_Structures/Entities/Structures/Blastdoor/BlastDoor.as
+++ b/Hope_TFlippy_TerritoryControl_Structures/Entities/Structures/Blastdoor/BlastDoor.as
@@ -7,7 +7,7 @@
 
 #include "CustomBlocks.as";
 
-void onInit(CBlob@ this)
+void onInit(CBlob@ this, bool open)
 {
 	this.getShape().SetRotationsAllowed(false);
 	this.getSprite().getConsts().accurateLighting = true;
@@ -15,6 +15,18 @@ void onInit(CBlob@ this)
 	this.Tag("blocks sword");
 	this.Tag("door");
 	this.Tag("blocks water");
+	
+	CSprite@ sprite = this.getSprite();
+	if (open)
+	{
+		sprite.SetZ(-100.0f);
+		sprite.SetAnimation("open");
+		this.getShape().getConsts().collidable = false;
+		this.getCurrentScript().tickFrequency = 3;
+		
+		this.getSprite().PlaySound("/Blastdoor_Buzzer.ogg", 1.00f, 1.00f);
+		// this.getSprite().PlaySound("/Blastdoor_Open.ogg", 1.00f, 1.00f);
+	}
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)

--- a/Hope_TFlippy_TerritoryControl_Structures/Entities/Structures/Factories/Assembler/Assembler.as
+++ b/Hope_TFlippy_TerritoryControl_Structures/Entities/Structures/Factories/Assembler/Assembler.as
@@ -259,6 +259,12 @@ void onInit(CBlob@ this)
 	this.Tag("builder always hit");
 	this.Tag("change team on fort capture");	
 	this.set_bool("state", true);
+	bool state = this.get_bool("state");
+	
+	//this should prevent cogs of a turned-off assembler from rotating after player's relogs a server
+	if (state == false) {
+		this.Untag("cogs");
+	}	//
 	
 	this.addCommandID("set");
 	this.addCommandID("state");	


### PR DESCRIPTION
Made changes should check states of assembler and balsdoor to make them work properly after player's relogging